### PR TITLE
fix: align the site with current writing and patch SEO/UX nits

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,7 +15,7 @@ enableGitInfo = true
     "profile.png"
   ]
 
-  description = 'Learn about a vast array of programming languages, frameworks, and technologies at BradCypert.com'
+  description = 'Systems programming in public — Zig, Gleam, Go, Rust, and whatever Brad Cypert is learning this month.'
 
   # Enable the darkmode toggle in header
   darkModeToggle = true
@@ -24,7 +24,7 @@ enableGitInfo = true
   enableSearch = true
 
   # Custom copyright - optional
-  copyright = "Copyright © 2022 - Brad Cypert · All rights reserved"
+  # Copyright year is rendered from the current date in layouts/partials/footer.html
   favicon = "/favicon.svg"
 
   # Color for the intro details and social links block, not applicable for dark mode
@@ -44,11 +44,13 @@ enableGitInfo = true
   hideOtherLanguages = false
 
   introTitle = "Hey! I'm Brad Cypert."
+  introSubtitle = "I write systems code in public — Zig, Gleam, and whatever I'm learning this month."
+  introBio = "Who am I?<br>I'm a programming language enthusiast. Sometimes I <a class=\"text-pink-900 dark:text-pink-200\" href=\"/blog\">write</a>. Sometimes I post content on <a class=\"text-pink-900 dark:text-pink-200\" href=\"https://www.youtube.com/@CodeWithCypert\">my YouTube channel, CodeWithCypert</a>."
   introPhoto = "/brad-w-luna.jpg"
 
   author = "Brad Cypert"
   logo = "/brad-w-luna.jpg"
-  header = "Tips and Tutorials for JavaScript, Flutter, and more."
+  header = "Brad Cypert"
   twitter = "bradcypert"
   github = "bradcypert"
 
@@ -81,6 +83,7 @@ DefaultContentLanguageInSubdir = true
   twitter = "https://twitter.com/bradcypert"
   linkedin = "https://linkedin.com/in/bradcypert"
   github = "https://github.com/bradcypert"
+  youtube = "https://www.youtube.com/@CodeWithCypert"
 
 [build]
   writeStats = true

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,4 +1,4 @@
 ---
-# Important: Front matter is required.
-# Because of this _index.md file, this directory is a branch bundle.
+title: "Blog"
+description: "Notes on Zig, Gleam, Go, Rust, and other languages — written while I'm still learning them."
 ---

--- a/content/blog/interfaces-in-zig.md
+++ b/content/blog/interfaces-in-zig.md
@@ -27,7 +27,7 @@ Indeed, they're used in Allocators, Readers, Writers, Streams, Formatters and mo
 
 It may not be immediately obvious that these are interfaces due to the lack of an `interface` or `implements` keyword.
 
-This article is intended to be a deep dive into how Zig implements interface-like abstractions using [**vtables**](https://en.wikipedia.org/wiki/Virtual_method_table), why the standard library uses them, how they compare to Go-style interfaces, and — most importantly — **when you should and should not use them in your own Zig code**. However, this article ultimately reflects my the depths of my own understanding and I strongly recommend that you do not use this as your only source of truth and opinions.
+This article is intended to be a deep dive into how Zig implements interface-like abstractions using [**vtables**](https://en.wikipedia.org/wiki/Virtual_method_table), why the standard library uses them, how they compare to Go-style interfaces, and — most importantly — **when you should and should not use them in your own Zig code**. However, this article ultimately reflects the depths of my own understanding and I strongly recommend that you do not use this as your only source of truth and opinions.
 
 ---
 
@@ -178,7 +178,7 @@ Conceptually, they still follow the same pattern:
 { buffer + state, vtable }
 ```
 
-But unlike `Allocator`, the *interface* is no longer just a thin handle — it is a full object with it's own state.
+But unlike `Allocator`, the *interface* is no longer just a thin handle — it is a full object with its own state.
 There are benefits to both approaches and ultimately this distinction does matter when designing your own interfaces.
 
 ---

--- a/content/blog/retro-building-an-smtp-server-in-gleam.md
+++ b/content/blog/retro-building-an-smtp-server-in-gleam.md
@@ -11,6 +11,8 @@ tags:
   - gleam
   - smtp
   - retrospective
+series:
+  - smtp-in-gleam
 description: "I started building an SMTP server in Gleam. Here's what I've learned so far (Part 1)"
 outline:
   what: "What's the main goal I am trying to convey"
@@ -21,16 +23,16 @@ outline:
 I've been building an SMTP server in Gleam lately. I won't say "From scratch" as I'm using Rawhat's wonderful [Glisten](https://github.com/rawhat/glisten) library, which provides the TCP transport layer,
 but outside of that, I'm not (currently) using any other libraries. What I've actually implemented so far is rather small. I haven't touched IMAP or POP and have just focused
 on reading TCP packets, parsing them as SMTP payloads, and responding to the client appropriately. I'm hoping to share my learnings and document my progress with this post and others.
-Lets get into it!
+Let's get into it!
 
 ## TCP is everywhere
 
 For most of our run-of-the-mill software development, when we send requests we're sending them over TCP. Now, you might say "I have never sent a TCP request in my life. I always use HTTP(s)" and to be honest,
-this would be a normal reaction. It's reasonable to lack the knowledge that HTTP is built ontop of TCP if the lowest level primitive you use is HTTP, but now that we've cleared the air, we can agree that
+this would be a normal reaction. It's reasonable to lack the knowledge that HTTP is built on top of TCP if the lowest level primitive you use is HTTP, but now that we've cleared the air, we can agree that
 you've likely been doing your networking over TCP. There are alternatives to TCP (UDP being the primary and the differences are probably out of the scope of this blog post) but HTTP (and HTTPS) is built
-ontop of TCP. Similarly, SMTP is also built on top of TCP.
+on top of TCP. Similarly, SMTP is also built on top of TCP.
 
-Armed with this information, we know that we can build an SMTP server (or an HTTP server) simply by building ontop of a TCP layer. In fact, TCP is such a common protocol to build ontop of that most languages
+Armed with this information, we know that we can build an SMTP server (or an HTTP server) simply by building on top of a TCP layer. In fact, TCP is such a common protocol to build on top of that most languages
 ship a standard library that includes support for a TCP layer, however, Gleam does not. Thankfully, an open source library named "Glisten" fits the bill quite nicely for us!
 
 ## A bit about Glisten
@@ -84,7 +86,7 @@ fn loop(state: session.SmtpSession, msg, conn) {
     Packet(bits) -> {
       session.print_session(state)
       let assert Ok(text) = bit_array.to_string(bits)
-      io.println("recieved message: " <> text)
+      io.println("received message: " <> text)
       process_lines(state.buffer <> text, state, conn)
     }
     _ -> glisten.continue(state)
@@ -253,7 +255,7 @@ fn handle_data_line(
 ```
 
 Here's where we're going to wire up our parsing logic from earlier! At this point, the code should hopefully be pretty clear to follow, but lets go through it. Data Lines are effectively the exception to the rest of this flow,
-so we detect those early and handle them separately. Similarly, greetings need to be handled differently and dont particularly need parsing, so we handle that here as well. Once we're through those two, we fall into our catch-all
+so we detect those early and handle them separately. Similarly, greetings need to be handled differently and don't particularly need parsing, so we handle that here as well. Once we're through those two, we fall into our catch-all
 which is where we parse our commands. Keep in mind that the last item of each branch is the return statement as you read through that code. Ultimately, we're just parsing and sending a response back at this point... which leads to a fantastic question.
 
 ## WHERE ARE MY EMAILS, BRAD
@@ -262,7 +264,7 @@ A fun rhetorical question since I'm typing this to myself. At this point, we hav
 
 So the next reasonable question should be "can our mail server query the mail in the remote GMAIL server that I use?" to which I would also reply "No." No, indeed. To do this, we'd need to support IMAP which we do not support (yet).
 
-"Okay, so we cant query the remote gmail SMTP servers, but _surely_ we can download the emails from GMAIL even if it were to delete them from the GMAIL servers and store them on our local server, right?". My reply to this would most likely be "Wow, you're leading with some very informed questions -- but no." This would be POP (Post Office Protocol), which we do not support (yet).
+"Okay, so we can't query the remote gmail SMTP servers, but _surely_ we can download the emails from GMAIL even if it were to delete them from the GMAIL servers and store them on our local server, right?". My reply to this would most likely be "Wow, you're leading with some very informed questions -- but no." This would be POP (Post Office Protocol), which we do not support (yet).
 
 So... if we try to send an email using our server, where DO they go? They disappear. This is ultimately a decision that can be made by the implementer. Maybe you'll store them in the filesystem. Maybe you'll even store them under user-specific, properly-permissioned directories so that users can SSH into your mail-server box and read their own emails. Maybe you'll store them in a database. Maybe it'll be SQLite. Maybe It'll be Dynamodb. Maybe you'll make a SaaS built on this SMTP server -- and this is all possible because you understand how it works.
 
@@ -274,4 +276,4 @@ So... if we try to send an email using our server, where DO they go? They disapp
 
 ## The End Game
 
-Learning is the end game. I hope you've enjoyed this little learning journey that we've been on together. Keep an eye out for more as I continue to build this out. Track the [repo here](https://github.com/bradcypert/sheesh), find live streams of building this on [my channel](https://www.youtube.com/bradcypert) and check back here for the next set of blog posts as we implement some of the "not yets" from above.  
+Learning is the end game. I hope you've enjoyed this little learning journey that we've been on together. Keep an eye out for more as I continue to build this out. This is [part 1 of the SMTP-in-Gleam series](/series/smtp-in-gleam/). Track the [repo here](https://github.com/bradcypert/sheesh), find live streams of building this on [my YouTube channel](https://www.youtube.com/@CodeWithCypert), and check back here for the next set of posts as we implement some of the "not yets" from above.  

--- a/content/blog/writing-a-b+-tree-in-zig.md
+++ b/content/blog/writing-a-b+-tree-in-zig.md
@@ -6,7 +6,7 @@ permalink: /todo
 author: "Brad Cypert"
 type: blog
 images:
-  - dart-mixins-cover.jpg
+  - zig-multithreading.jpeg
 tags:
     - Zig
     - Database
@@ -37,7 +37,7 @@ A B+ Tree is a self-balancing tree data structure that maintains sorted data and
 
 ### B+ Tree vs B-Tree: The Key Differences
 
-If your familiar with your fundamental DS&A's, you may be thinking that the "+" is actually a typo and should be "-". There is no typo and we're indeed talking about a B+ Tree (B Plus Tree) and not a B-Tree. While both are balanced trees, B+ Trees have some crucial advantages for database applications:
+If you're familiar with your fundamental DS&A's, you may be thinking that the "+" is actually a typo and should be "-". There is no typo and we're indeed talking about a B+ Tree (B Plus Tree) and not a B-Tree. While both are balanced trees, B+ Trees have some crucial advantages for database applications:
 
 | Feature | B-Tree | B+ Tree |
 |---------|--------|---------|
@@ -375,7 +375,7 @@ The B+ Tree implementation delivers excellent performance characteristics:
 
 ### Scalability Testing
 
-Our tests demonstrate real scalability:
+Our tests cover the split path, not large-scale load:
 
 ```zig
 // Successfully tested with 50+ keys triggering automatic splits
@@ -465,7 +465,7 @@ Optimize initial data loading by building trees bottom-up.
 
 Building a B+ Tree from scratch taught me immense respect for database engineers. The combination of algorithmic complexity, memory management, and concurrency creates challenges that require careful thought and elegant solutions.
 
-The LowkeyDB B+ Tree implementation demonstrates that Zig's safety, performance, and expressiveness make it an excellent choice for systems programming. The result is a production-ready data structure that scales from small embedded applications to larger datasets.
+The LowkeyDB B+ Tree implementation demonstrates that Zig's safety, performance, and expressiveness make it an excellent choice for systems programming. It's a working walkthrough of an in-progress engine — useful as a learning artifact, not a claim that this is production-ready.
 
 Key takeaways:
 
@@ -479,4 +479,4 @@ The complete implementation shows that building database-quality data structures
 
 ## Code Repository
 
-The complete LowkeyDB implementation, including the B+ Tree, is available with comprehensive examples and documentation. The codebase demonstrates real-world usage of advanced Zig features and provides a solid foundation for further database development.
+The complete LowkeyDB implementation, including the B+ Tree, lives at [github.com/bradcypert/lowkeydb](https://github.com/bradcypert/lowkeydb). The codebase is a snapshot of the work described here — including the current limits around recursive internal splits.

--- a/content/blog/zigs-release-modes.md
+++ b/content/blog/zigs-release-modes.md
@@ -11,7 +11,7 @@ tags:
   - zig
 versions:
   zig: "0.15.1"
-description: "Zig has multiple release modes to suite each individual's needs. Here's when to use one over the other."
+description: "Zig has multiple release modes to suit each individual's needs. Here's when to use one over the other."
 outline:
   what: "What's the main goal I am trying to convey"
   why: "Why does anyone care?"

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -1,29 +1,42 @@
 ---
-title: "Brad Cypert - Software Technologist in Louisville Kentucky"
-description: "Louisville, Kentucky based software architect passionate about building applications at scale. Frequent blogger. Coffee lover."
+title: "About Brad Cypert"
+description: "Software engineer in Louisville, Kentucky. Currently writing systems code in public — Zig, Gleam, Go, and Rust."
 date: 2014-10-23
+lastmod: 2026-08-30
 status: publish
 permalink: /about
 author: "Brad Cypert"
 excerpt: ""
 type: page
 id: 14
+hideMeta: true
 ---
 
-**I’m passionate about Flutter, Rust, Go, and Software Architecture.**  
+**I write systems code in public.** Zig, Gleam, a bit of Go and Rust, and whatever else I'm learning this month.
+
 **I’m also passionate about being passionate about things.**
 
 #### From the Beginning
 
-I started writing my first bits of ‘code’ playing a game called Anarchy Online. The game offered a neat scripting system and a HTML rendering engine that was way ahead of it’s time. After realizing how cool that was, I took some Java classes in highschool. After realizing how cool THAT was, I decided to make a career out of it, pursuing it through college and self-education. Now, I openly seek out opportunities to educate others and further my own education.
+I started writing my first bits of ‘code’ playing a game called Anarchy Online. The game offered a neat scripting system and a HTML rendering engine that was way ahead of its time. After realizing how cool that was, I took some Java classes in high school. After realizing how cool THAT was, I decided to make a career out of it, pursuing it through college and self-education. Now, I openly seek out opportunities to educate others and further my own education.
 
-#### Languages & Tools
+#### What I'm focused on
 
-I can list dozens of languages that I can “Hello World” in, but I’m not going to. Instead, I’ll tell you that I’m currently focusing most of my efforts on Rust, Go, and Dart at this time. Particularly, I'm learning Rust, writing Go when it makes sense and looking to grow Dart's developer ecosystem. Help me grow Dart's developer ecosystem (particularly interested in things outside of Flutter), by supporting or contributing to one of my projects like [Steward](https://github.com/PyreStudios/steward), [Bosun](https://github.com/PyreStudios/bosun), [Dwell](https://github.com/PyreStudios/dwell), or [Popshop](https://github.com/PyreStudios/popshop).
+Right now that's **Zig** (interfaces, C interop, a B+ tree for [LowkeyDB](https://github.com/bradcypert/lowkeydb)) and **Gleam** (an SMTP server called [sheesh](https://github.com/bradcypert/sheesh)). I still reach for Go when I want to ship, and I still care about Dart — just not as the headline.
+
+A few older projects I still like pointing people at: [Steward](https://github.com/bradcypert/steward), [Bosun](https://github.com/bradcypert/bosun), [Dwell](https://github.com/bradcypert/dwell), and [Popshop](https://github.com/bradcypert/popshop).
+
+If you want the writing, start with:
+
+- [Interfaces in Zig](/interfaces-in-zig/)
+- [Retro: Building an SMTP Server in Gleam - Part 1](/retro-building-an-smtp-server-in-gleam/)
+- [the rest of the blog](/blog)
+
+I also post on [YouTube as CodeWithCypert](https://www.youtube.com/@CodeWithCypert).
 
 #### Talks
 
-If I’m talking about something at a conference, event, or meetup, It’s probably something I’ve blogged about or am about to blog about. If you can learn something from me, I don’t believe you should have to listen to me talk about it when the internet offers a great medium for transcripts via my blog.
+If I’m talking about something at a conference, event, or meetup, it’s probably something I’ve blogged about or am about to blog about. If you can learn something from me, I don’t believe you should have to listen to me talk about it when the internet offers a great medium for transcripts via my blog.
 
 #### More Information Than You Could Possibly Want.
 

--- a/content/page/gleam-resources.md
+++ b/content/page/gleam-resources.md
@@ -1,0 +1,17 @@
+---
+title: "Gleam Resources"
+description: "A friendly language for building type-safe systems on the Erlang VM."
+date: 2026-06-11
+status: publish
+permalink: /gleam-resources
+author: "Brad Cypert"
+excerpt: ""
+type: page
+---
+
+A friendly language for building type-safe systems on the Erlang VM. I'm currently using it to learn networking from the TCP layer up.
+
+### Building an SMTP server
+
+- [Retro: Building an SMTP Server in Gleam - Part 1](/retro-building-an-smtp-server-in-gleam/)
+- [sheesh on GitHub](https://github.com/bradcypert/sheesh)

--- a/content/page/go-resources.md
+++ b/content/page/go-resources.md
@@ -1,0 +1,28 @@
+---
+title: "Go Resources"
+description: "Simple, boring, and excellent for servers, CLIs, and gRPC."
+date: 2024-11-08
+status: publish
+permalink: /go-resources
+author: "Brad Cypert"
+excerpt: ""
+type: page
+---
+
+Simple, boring, and excellent for servers, CLIs, and gRPC. The language I reach for when I want to ship.
+
+### Language
+
+- [How Golang Interfaces Work](/how-golang-interfaces-work/)
+- [Golang: What is a receiver function?](/go-receiver-function/)
+- [Go Channels](/go-channels/)
+- [Go's WaitGroup](/go-waitgroup/)
+- [Log is dead, long live slog](/go-slog/)
+
+### Networking and tooling
+
+- [gRPC fundamentals with Go](/grpc-fundamentals-with-go/)
+- [Testing a Cobra CLI in Go](/testing-a-cobra-cli-in-go/)
+- [Using Mongo's ObjectIDs with Go-Graphql](/using-mongos-objectids-with-go-graphql/)
+- [An Introduction to Targeting Web Assembly with Golang](/an-introduction-to-targeting-web-assembly-with-golang/)
+- [Building a Soil Moisture Sensor in TinyGo with Arduino](/building-a-soil-moisture-sensor-in-tinygo-with-arduino/)

--- a/content/page/rust-resources.md
+++ b/content/page/rust-resources.md
@@ -1,0 +1,23 @@
+---
+title: "Rust Resources"
+description: "Memory safety without a GC. Notes on traits, Drop, From/Into, and a few side projects."
+date: 2024-03-20
+status: publish
+permalink: /rust-resources
+author: "Brad Cypert"
+excerpt: ""
+type: page
+---
+
+Memory safety without a GC. These are the Rust notes I still stand behind.
+
+### Language
+
+- [Rust's Drop trait](/rust-drop-trait/)
+- [From and Into](/rust-from-into/)
+- [Boxing things in Rust](/boxing-things-in-rust/)
+
+### Projects
+
+- [Naive Bayes Classifier in Rust trained on Taylor Swift lyrics](/naive-bayes-classifier-in-rust-with-taylor-swift/)
+- [Chili cookoff with Rust, Rocket, Render, and Supabase](/chili-cookoff-with-rust-rocket-render-and-supabase/)

--- a/content/page/zig-resources.md
+++ b/content/page/zig-resources.md
@@ -12,8 +12,14 @@ id: 2232
 
 Blazingly fast. No hidden control flow. No hidden memory allocations. No preprocessor. No macros. Zig is a blessing to the programming language community.
 
-### General Zig
+### Language internals
 
+- [Interfaces in Zig](/interfaces-in-zig/)
 - [Zig's release modes](/zigs-release-modes/)
 - [Multithreading in Zig](/multithreading-zig/)
+- [Using C libraries in Zig](/using-c-libraries-in-zig/)
 - [Add git dependencies with zig fetch](/adding-dependencies-to-your-zig-project-with-zig-fetch/)
+
+### Systems projects
+
+- [Writing a B+ Tree in Zig](/writing-a-b-tree-in-zig/)

--- a/content/series/_index.md
+++ b/content/series/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Series"
+description: "Multi-part writeups. Start here if you want the whole story, not just one post."
+---

--- a/content/series/smtp-in-gleam/_index.md
+++ b/content/series/smtp-in-gleam/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Building an SMTP Server in Gleam"
+description: "A learning-in-public series on implementing SMTP (and later, maybe IMAP/POP) in Gleam."
+---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+  {{- partial "intro.html" . -}}
+
+  {{- partial "language-resources.html" . -}}
+
+  {{ $frontBundle := site.Params.frontBundle | default "blog" }}
+
+  <div class="bg-blue-50 dark:bg-pink-900 p-6 mx-auto">
+    <h3 class="text-2xl text-center">Hot off the press:</h3>
+    <div class="container p-6 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-8">
+      {{ range first 6 (where site.RegularPages.ByDate.Reverse "Type" $frontBundle)  }}
+        {{- partial "blog-card.html" . -}}
+      {{ end }}
+    </div>
+  </div>
+
+  {{ if gt (len (where site.RegularPages.ByDate.Reverse "Type" $frontBundle)) 6 }}
+  <div class="text-center mb-8">
+    <a class="px-8 py-3 rounded transition-colors bg-yellow-400 text-gray-900 hover:bg-yellow-300 dark:bg-pink-300 dark:text-gray-900 dark:hover:bg-pink-200 font-semibold"
+      href="{{ (index (site.Menus.main) 0).URL | absLangURL }}" lang="{{ .Lang }}">
+      {{ i18n "morePosts" }}
+    </a>
+  </div>
+  {{ end }}
+
+  {{- partial "social.html" . -}}
+{{ end }}

--- a/layouts/partials/blog-card.html
+++ b/layouts/partials/blog-card.html
@@ -1,0 +1,36 @@
+<div class="p-2">
+<a href="{{ .Permalink }}">
+  {{ if isset .Params.images 0 }}
+  {{ $image := index .Params.images 0 }}
+  {{ $src := resources.Get (printf $image) }}
+  {{ $alt := .Title }}
+  <div class="relative">
+    <div class="image-hover">
+      {{ with $src }}
+        {{ $src := $src.Resize "400x webp"}}
+        <img src="{{ $src.RelPermalink }}" alt="{{ $alt }}" class="rounded-lg shadow-sm w-full h-52 object-cover" />
+      {{ end }}
+    <div class="hover-text bg-black text-white p-2 rounded-md">Learn More</div>
+    </div>
+    {{ if not (or (or site.Params.hideMeta .Params.hideMeta) false) }}
+    <div class="absolute top-4 right-4 rounded shadow bg-white text-gray-900 dark:bg-gray-900 dark:text-white text-sm px-2 py-0.5">
+      {{ partial "date.html" (dict "date" .Date "language" $.Page.Language "format" "short") }}
+    </div>
+    {{ end }}
+  </div>
+  {{ end }}
+  <div class="my-2 text-xl font-semibold">{{ .Params.title }}</div>
+  <div>{{ .Params.description }}</div>
+</a>
+{{ if not (or (or site.Params.hideOtherLanguages .Params.hideOtherLanguages) false) }}
+  {{ if .IsTranslated -}}
+    <div style="font-style: italic;font-size: smaller;">
+      {{- $sortedTranslations := sort .Translations "Site.Language.Weight" -}}
+      {{- $links := apply $sortedTranslations "partial" "translation_link.html" "." -}}
+      {{- $cleanLinks := apply $links "chomp" "." -}}
+      {{- $linksOutput := delimit $cleanLinks (i18n "translationsSeparator") -}}
+      {{ i18n "translationsLabel" }}{{ $linksOutput }}
+    </div>
+  {{- end }}
+{{ end }}
+</div>

--- a/layouts/partials/date.html
+++ b/layouts/partials/date.html
@@ -1,0 +1,13 @@
+{{ if or (eq "de" .language.Lang) (eq "fr" .language.Lang) }}
+  {{ if eq "long" .format }}
+    {{ .date.Format "02" }}. {{ i18n (.date.Format "January")}} {{ .date.Format "2006"}}
+  {{ else }}
+    {{ .date.Format "02" }}. {{ substr (i18n (.date.Format "January")) 0 3 }} {{ .date.Format "2006"}}
+  {{ end }}
+{{ else }}
+  {{ if eq "long" .format }}
+    {{ .date.Format "January 2, 2006" }}
+  {{ else }}
+    {{ .date.Format "Jan 2, 2006" }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,75 @@
+<footer class="container p-6 mx-auto flex justify-between items-center">
+  <span class="text-sm font-light">
+    Copyright © {{ dateFormat "2006" now }} - Brad Cypert · All rights reserved
+  </span>
+  <span onclick="window.scrollTo({top: 0, behavior: 'smooth'})" class="p-1 cursor-pointer" role="button" aria-label="Back to top" tabindex="0">
+    <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 24 24" stroke-width="1.5"
+      stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M18 15l-6 -6l-6 6h12" />
+    </svg>
+  </span>
+</footer>
+
+{{ if site.Params.enableSearch }}
+{{- partial "search-ui.html" . -}}
+{{ end }}
+
+{{ if ge (len site.Languages) 3 }}
+<script>
+  const languageMenuButton = document.querySelector('.language-switcher');
+  const languageDropdown = document.querySelector('.language-dropdown');
+  languageMenuButton.addEventListener('click', (evt) => {
+    evt.preventDefault()
+    if (languageDropdown.classList.contains('hidden')) {
+      languageDropdown.classList.remove('hidden')
+      languageDropdown.classList.add('flex')
+    } else {
+      languageDropdown.classList.add('hidden');
+      languageDropdown.classList.remove('flex');
+    }
+  })
+</script>
+{{ end }}
+
+{{ if site.Params.darkModeToggle }}
+<script>
+  // On page load or when changing themes
+  const darkmode = document.querySelector('.toggle-dark-mode');
+  function toggleDarkMode() {
+    if (document.documentElement.classList.contains('dark')) {
+      document.documentElement.classList.remove('dark')
+      localStorage.setItem('darkmode', 'light')
+    } else {
+      document.documentElement.classList.add('dark')
+      localStorage.setItem('darkmode', 'dark')
+    }
+  }
+  if (darkmode) {
+    darkmode.addEventListener('click', toggleDarkMode);
+  }
+
+  const darkStorage = localStorage.getItem('darkmode');
+  const isBrowserDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  if (!darkStorage && isBrowserDark) {
+    document.documentElement.classList.add('dark');
+  }
+
+  if (darkStorage && darkStorage === 'dark') {
+    toggleDarkMode();
+  }
+</script>
+{{ end }}
+
+<script>
+  const mobileMenuButton = document.querySelector('.mobile-menu-button')
+  const mobileMenu = document.querySelector('.mobile-menu')
+  function toggleMenu() {
+    mobileMenu.classList.toggle('hidden');
+    mobileMenu.classList.toggle('flex');
+  }
+  if(mobileMenu && mobileMenuButton){
+    mobileMenuButton.addEventListener('click', toggleMenu)
+  }
+</script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,75 @@
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <link rel="icon" href="{{ if (isset site.Params "favicon") }}{{ site.Params.favicon }}{{ else }}/favicon.ico{{ end }}">
+  <link rel="canonical" href="{{ .Permalink }}" />
+
+  <title>
+  {{- if .IsHome -}}
+    {{ site.Title }}{{ with site.Params.description }} · {{ . }}{{ end }}
+  {{- else if .Title -}}
+    {{ .Title }} - {{ site.Title }}
+  {{- else -}}
+    {{ site.Title }}
+  {{- end -}}
+  </title>
+  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}" />
+  {{- if .Keywords }}
+  <meta name="keywords" content="{{ delimit .Keywords "," }}" />
+  {{ end -}}
+  {{- if .Params.Author }}
+  <meta name="author" content="{{ .Params.Author}}" />
+  {{ end -}}
+
+  {{ hugo.Generator }}
+
+  {{- $styles := resources.Get "css/styles.css" | postCSS (dict "config" "./assets/css/postcss.config.js") -}}
+  {{- if hugo.IsServer }}
+  <link rel="stylesheet" href="{{ $styles.RelPermalink }}" />
+  {{ else }}
+  {{- $styles := $styles| minify | fingerprint | resources.PostProcess -}}
+  <link
+    rel="stylesheet"
+    href="{{ $styles.Permalink }}"
+    integrity="{{ $styles.Data.Integrity }}"
+  />
+  {{ end -}}
+
+  <script type="module" src="/js/web-components.es.js"></script>
+
+  {{ if .Params.math }}
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.css"
+      integrity="sha384-D+9gmBxUQogRLqvARvNLmA9hS2x//eK1FhVb9PiU86gmcrBrJAQT8okdJ4LMp2uv"
+      crossorigin="anonymous"
+    >
+
+    <script defer
+      src="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/katex.min.js"
+      integrity="sha384-483A6DwYfKeDa0Q52fJmxFXkcPCFfnXMoXblOkJ4JcA8zATN6Tm78UNL72AKk+0O"
+      crossorigin="anonymous"
+    ></script>
+
+    <script defer
+      src="https://cdn.jsdelivr.net/npm/katex@0.10.0-rc.1/dist/contrib/auto-render.min.js"
+      integrity="sha384-yACMu8JWxKzSp/C1YV86pzGiQ/l1YUfE8oPuahJQxzehAjEt2GiQuy/BIvl9KyeF"
+      crossorigin="anonymous"
+      onload="renderMathInElement(document.body);"
+    ></script>
+  {{ end }}
+
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+  {{ end -}}
+
+  {{ template "_internal/opengraph.html" . }}
+  {{ template "_internal/twitter_cards.html" . }}
+
+  {{ if gt (len site.Languages) 1}}
+  <meta name="lang" content="{{ site.Language }}" />
+  {{ end }}
+
+  {{ partial "schema.html" . }}
+</head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,7 @@
   {{- $styles := $styles| minify | fingerprint | resources.PostProcess -}}
   <link
     rel="stylesheet"
-    href="{{ $styles.Permalink }}"
+    href="{{ $styles.RelPermalink }}"
     integrity="{{ $styles.Data.Integrity }}"
   />
   {{ end -}}

--- a/layouts/partials/intro.html
+++ b/layouts/partials/intro.html
@@ -1,0 +1,18 @@
+<section class="{{ site.Params.ascentColor | default "bg-pink-50" }} dark:bg-gray-900">
+  <div class="container max-w-screen-lg mx-auto px-6 py-12 grid md:grid-cols-2 gap-4 lg:gap-16 items-center">
+    <div>
+      <h1 class="text-4xl font-bold mb-4">{{ site.Params.introTitle | safeHTML}}</h1>
+        <h2 class="text-xl mb-6">{{ site.Params.introSubtitle | default "I write systems code in public — Zig, Gleam, and whatever I'm learning this month." }}</h2>
+
+        <h3 class="text-xl mb-6">{{ site.Params.introBio | default "Who am I?<br>I'm a programming language enthusiast. Sometimes I write. Sometimes I post on YouTube." | safeHTML }}</h3>
+
+
+    </div>
+    {{ $src := resources.Get site.Params.introPhoto }}
+    {{ $title := site.Title }}
+      {{ with $src }}
+        {{ $src := $src.Resize "x600 webp"}}
+        <img class="rounded-lg shadow-sm" src="{{ $src.RelPermalink  }}" height="600" alt="Brad Cypert with his dog Luna" />
+      {{ end }}
+  </div>
+</section>

--- a/layouts/partials/language-logo.html
+++ b/layouts/partials/language-logo.html
@@ -1,0 +1,26 @@
+{{ $allowed := dict
+    "rust" "rust/rust-plain.svg"
+    "dart" "dart/dart-original.svg"
+    "flutter" "flutter/flutter-original.svg"
+    "go" "go/go-original-wordmark.svg"
+    "react" "react/react-original.svg"
+    "typescript" "typescript/typescript-original.svg"
+    "clojure" "clojure/clojure-original.svg"
+    "javascript" "javascript/javascript-original.svg"
+    "php" "php/php-plain.svg"
+    "laravel" "laravel/laravel-plain.svg"
+    "python" "python/python-original.svg"
+    "mongo" "mongodb/mongodb-original.svg"
+    "scala" "scala/scala-original.svg"
+    "java" "java/java-original.svg"
+    "gradle" "gradle/gradle-original.svg"
+    "kotlin" "kotlin/kotlin-original.svg"
+    "zig" "zig/zig-original.svg"
+    "gleam" "gleam/gleam-original.svg"
+    "android" "android/android-original.svg" }}
+
+{{ if isset $allowed . }}
+    <img style="display: inline-block" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{index $allowed .}}" alt="{{.}}" width="24" height="24" />
+{{ else }}
+    {{ . }}
+{{ end }}

--- a/layouts/partials/language-resources.html
+++ b/layouts/partials/language-resources.html
@@ -1,0 +1,29 @@
+<div class="container p-6 mx-auto">
+    <h3 class="text-2xl">Language Specific Resources:</h3>
+
+    {{ $resources := slice
+        (dict "name" "Zig" "description" "Blazingly fast. No hidden control flow. No hidden memory allocations. No preprocessor. No macros.")
+        (dict "name" "Gleam" "description" "A friendly language for building type-safe systems on the Erlang VM. I'm currently building an SMTP server in it.")
+        (dict "name" "Go" "description" "Simple, boring, and excellent for servers, CLIs, and gRPC. The language I reach for when I want to ship.")
+        (dict "name" "Rust" "description" "Memory safety without a GC. Notes on traits, Drop, From/Into, and a few side projects.")
+        (dict "name" "Dart" "description" "Dart is a client-optimized language for fast apps on any platform. Flutter allows developers to build apps for any type of screen.")
+        (dict "name" "Clojure" "description" "Clojure is a dynamic, general-purpose programming language, combining the approachability and interactive development of a scripting language with an efficient and robust infrastructure for multithreaded programming.")
+        (dict "name" "Java" "description" "Java is known for its “Write-Once-Run-Anywhere” mantra and helps run code on servers, phones, microwaves, and more!")
+        (dict "name" "JavaScript" "description" "The language(s) of the web. TypeScript as well as JavaScript library and framework articles can be found here, too!")
+        (dict "name" "Kotlin" "description" "Kotlin is a cross-platform, statically-typed language that often targets the JVM. It's used for web development, Android development, and much more.")
+        (dict "name" "PHP" "description" "PHP was one of the first programming languages that I learned and while it's not something I often write these days, I still find myself appreciating the stateless nature of web development, as well as Laravel and, sometimes, Wordpress.")
+        (dict "name" "Scala" "description" "Scala combines object-oriented and functional programming in one concise, high-level language. Note: Most of these examples will be using Scala 2.X")
+      }}
+
+    <div class="container p-6 mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-8">
+      {{ range $resources }}
+      <div class="p-2">
+        <a href="/{{lower .name}}-resources">
+          <div class="my-2 text-xl font-semibold">{{- partial "language-logo.html" (lower .name) -}}{{ .name }}</div>
+          <div>{{ .description }}</div>
+        </a>
+        </div>
+
+      {{ end }}
+    </div>
+</div>

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,0 +1,42 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {{ if eq .Section "blog" }}
+    {
+      "@type": "BlogPosting",
+      "headline": {{ .Title }},
+      "image": {{ if (isset .Params.Images 0) }}{{ index (.Params.images) 0 | absURL }}{{ else }}{{ site.Params.logo | absURL }}{{ end }},
+      "datePublished": {{ .PublishDate }},
+      "dateModified": {{ .Lastmod }},
+      "author": {
+        "@type": "Person",
+        "name": {{ site.Params.author }}
+      },
+      "mainEntityOfPage": { "@type": "WebPage", "url": {{ .Permalink }} },
+      "publisher": {
+        "@type": "Organization",
+        "name": {{ site.Title }},
+        "logo": {
+          "@type": "ImageObject",
+          "url": {{ site.Params.logo | absURL }}
+        }
+      },
+      "description": {{ .Summary | plainify }},
+      "keywords": [{{ range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}]
+    },
+    {{ end }}
+    {
+      "@type": "Person",
+      "name": {{ site.Params.author }},
+      "url": {{ site.BaseURL }},
+      "sameAs": [
+        "https://twitter.com/{{ site.Params.twitter }}",
+        "https://github.com/{{ site.Params.github }}",
+        "https://linkedin.com/in/bradcypert",
+        "https://www.youtube.com/@CodeWithCypert"
+      ]
+    }
+  ]
+}
+</script>

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.bradcypert.com/sitemap.xml

--- a/themes/blist/layouts/partials/header.html
+++ b/themes/blist/layouts/partials/header.html
@@ -69,7 +69,7 @@
 
     {{ if site.Params.enableSearch }}
     <li class="grid place-items-center">
-      <span class="open-search inline-block cursor-pointer">
+      <span class="open-search inline-block cursor-pointer" role="button" aria-label="Search" tabindex="0">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5"
           stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
           <path stroke="none" d="M0 0h24v24H0z" fill="none" />
@@ -82,7 +82,7 @@
 
     {{ if site.Params.darkModeToggle }}
     <li class="grid place-items-center">
-      <span class="toggle-dark-mode inline-block cursor-pointer">
+      <span class="toggle-dark-mode inline-block cursor-pointer" role="button" aria-label="Toggle dark mode" tabindex="0">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5"
           stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
           <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/themes/blist/layouts/partials/social.html
+++ b/themes/blist/layouts/partials/social.html
@@ -306,7 +306,7 @@
       {{ with site.BaseURL }}
       <li>
         <a
-          href="{{.}}/index.xml"
+          href="{{ "index.xml" | absURL }}"
           target="_blank"
           rel="noopener"
           aria-label="RSS feed"


### PR DESCRIPTION
## Summary
This implements the review of bradcypert.com: make the homepage and About match the current Zig/Gleam systems-in-public writing, then fix the cheap SEO/UX bugs around that.

- Rewrite hero + About around current work; add Gleam/Go/Rust hubs and fill in Zig resources
- Fix empty blog title/H1, 2-digit dates (`Jun 10, 26`), double-slash RSS, stale copyright year, duplicate Open Graph tags, and schema `sameAs` placeholders
- Add YouTube to Follow me, sitemap in robots.txt, series page for SMTP Part 1
- Proofread recent Zig/Gleam posts; swap the Dart-mixins cover off the B+ tree article; link LowkeyDB

## Test Plan
- [ ] `hugo` build succeeds
- [ ] Homepage title/description/hero copy look right in light and dark mode
- [ ] `/blog` title is "Blog - BradCypert.com" with an H1
- [ ] RSS icon hits `https://www.bradcypert.com/index.xml` (single slash)
- [ ] `/zig-resources`, `/gleam-resources`, `/go-resources`, `/rust-resources` all 200
- [ ] SMTP post links the series + `@CodeWithCypert`
